### PR TITLE
refactor: extract error handling pattern in BitfinexAPIClient

### DIFF
--- a/bitfinex_maker_kit/core/trading_facade.py
+++ b/bitfinex_maker_kit/core/trading_facade.py
@@ -6,7 +6,7 @@ components to provide a unified trading interface while maintaining
 separation of concerns.
 """
 
-from typing import Any
+from typing import Any, cast
 
 from ..utilities.constants import OrderSide, OrderSubmissionError
 from .api_client import BitfinexAPIClient, create_api_client
@@ -39,7 +39,7 @@ class TradingFacade:
 
     def get_orders(self) -> list[Any]:
         """Get all active orders."""
-        return self.api_client.get_orders()
+        return cast(list[Any], self.api_client.get_orders())
 
     def cancel_order(self, order_id: int) -> Any:
         """Cancel a single order by ID."""


### PR DESCRIPTION
## Summary
- Extract repetitive error handling into reusable `@api_error_handler` decorator
- Apply to 6 API methods: get_orders, cancel_order, cancel_order_multi, get_wallets, get_ticker, get_trades
- Preserve submit_order error handling for POST_ONLY safety context

## Test plan
- [x] All existing tests pass
- [x] MyPy type checking passes
- [x] Ruff linting passes
- [x] Error behavior remains identical
- [x] POST_ONLY safety enforcement preserved

🤖 Generated with [Claude Code](https://claude.ai/code)